### PR TITLE
change toml-rb to toml gem

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -26,7 +26,7 @@ directory node['chronograf']['local_database_dir'] do
 end
 
 file node['chronograf']['conf_file'] do
-  content TOML.dump(node['chronograf']['config'])
+  content TOML::Generator.new(node['chronograf']['config']).body
   notifies :restart, 'service[chronograf]' if node['chronograf']['notify_restart'] && !node['chronograf']['disable_service']
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,11 @@ node.default['chronograf']['config']['Bind'] = "#{node['chronograf']['bind_host'
 node.default['chronograf']['config']['LocalDatabase'] = ::File.join(node['chronograf']['local_database_dir'], 'chronograf.db')
 
 if Chef::Resource::ChefGem.method_defined?(:compile_time)
-  chef_gem 'toml-rb' do
+  chef_gem 'toml' do
     compile_time true
   end
 else
-  chef_gem 'toml-rb' do
+  chef_gem 'toml' do
     action :nothing
   end.run_action(:install)
 end


### PR DESCRIPTION
The influxdb cookbook changed gem from toml-rb to toml. These two gems are incompatible which each other and thus, install of the influxdb-cookbook blocks install of chronograf.

See https://github.com/bdangit/chef-influxdb/pull/143