### PR TITLE
include_repository: make repository optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,8 @@ default['chronograf']['yum']['baseurl'] = value_for_platform(
   %w(centos redhat fedora) => { 'default' => 'https://repos.influxdata.com/rhel/6/$basearch/stable' }
 )
 
+default['chronograf']['include_repository'] = true
+
 default['chronograf']['yum']['description'] = 'InfluxDB Repository - RHEL $releasever'
 default['chronograf']['yum']['gpgcheck'] = true
 default['chronograf']['yum']['enabled'] = true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,6 +26,7 @@ when 'debian'
     key node['chronograf']['apt']['key']
     distribution node['chronograf']['apt']['distribution']
     action node['chronograf']['apt']['action']
+    only_if { node['chronograf']['include_repository'] }
   end
 when 'rhel'
   # yum repository configuration
@@ -36,6 +37,7 @@ when 'rhel'
     gpgkey node['chronograf']['yum']['gpgkey']
     enabled node['chronograf']['yum']['enabled']
     action node['chronograf']['yum']['action']
+    only_if { node['chronograf']['include_repository'] }
   end
 end
 


### PR DESCRIPTION
make the repository optional to work better with influxdb and telegraf cookbooks. Uses same attribute naming as the telegraf cookbook.